### PR TITLE
Add needed XSD resources as local files

### DIFF
--- a/app/resources/xsd/dc_basic.xsd
+++ b/app/resources/xsd/dc_basic.xsd
@@ -10,7 +10,7 @@
   </xs:annotation>
 
   <xs:import namespace="http://www.w3.org/XML/1998/namespace"
-    schemaLocation="http://www.w3.org/2001/03/xml.xsd">
+    schemaLocation="xml.xsd">
   </xs:import>
   <xs:import namespace="http://purl.org/dc/elements/1.1/" schemaLocation="dc.xsd" />
   <xs:import namespace="http://purl.org/dc/terms/" schemaLocation="dcterms.xsd" />

--- a/app/resources/xsd/mets.xsd
+++ b/app/resources/xsd/mets.xsd
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xsd:schema targetNamespace="http://www.loc.gov/METS/" xmlns="http://www.loc.gov/METS/" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" attributeFormDefault="unqualified">
-  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="http://www.loc.gov/standards/xlink/xlink.xsd"/>
+  <xsd:import namespace="http://www.w3.org/1999/xlink" schemaLocation="xlink.xsd"/>
 	
   <xsd:annotation>
 

--- a/app/resources/xsd/xlink.xsd
+++ b/app/resources/xsd/xlink.xsd
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- METS XLink Schema, v. 2, Nov. 15, 2004 -->
+<schema targetNamespace="http://www.w3.org/1999/xlink" xmlns="http://www.w3.org/2001/XMLSchema" xmlns:xlink="http://www.w3.org/1999/xlink" elementFormDefault="qualified">
+  <!--  global attributes  --> 
+  <attribute name="href" type="anyURI"/>
+  <attribute name="role" type="string"/>
+  <attribute name="arcrole" type="string"/>
+  <attribute name="title" type="string"/> 
+  <attribute name="show">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="new"/> 
+	<enumeration value="replace"/> 
+	<enumeration value="embed"/> 
+	<enumeration value="other"/> 
+	<enumeration value="none"/> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="actuate">
+    <simpleType>
+      <restriction base="string">
+	<enumeration value="onLoad"/> 
+	<enumeration value="onRequest"/> 
+	<enumeration value="other"/> 
+	<enumeration value="none"/> 
+      </restriction>
+    </simpleType>
+  </attribute>
+  <attribute name="label" type="string"/> 
+  <attribute name="from" type="string"/> 
+  <attribute name="to" type="string"/> 
+  <attributeGroup name="simpleLink">
+    <attribute name="type" type="string" fixed="simple" form="qualified"/> 
+    <attribute ref="xlink:href" use="optional"/> 
+    <attribute ref="xlink:role" use="optional"/> 
+    <attribute ref="xlink:arcrole" use="optional"/> 
+    <attribute ref="xlink:title" use="optional"/> 
+    <attribute ref="xlink:show" use="optional"/> 
+    <attribute ref="xlink:actuate" use="optional"/> 
+  </attributeGroup>
+  <attributeGroup name="extendedLink">
+    <attribute name="type" type="string" fixed="extended" form="qualified"/> 
+    <attribute ref="xlink:role" use="optional"/> 
+    <attribute ref="xlink:title" use="optional"/> 
+  </attributeGroup>
+  <attributeGroup name="locatorLink">
+    <attribute name="type" type="string" fixed="locator" form="qualified"/> 
+    <attribute ref="xlink:href" use="required"/> 
+    <attribute ref="xlink:role" use="optional"/> 
+    <attribute ref="xlink:title" use="optional"/> 
+    <attribute ref="xlink:label" use="optional"/> 
+  </attributeGroup>
+  <attributeGroup name="arcLink">
+    <attribute name="type" type="string" fixed="arc" form="qualified"/> 
+    <attribute ref="xlink:arcrole" use="optional"/> 
+    <attribute ref="xlink:title" use="optional"/> 
+    <attribute ref="xlink:show" use="optional"/> 
+    <attribute ref="xlink:actuate" use="optional"/> 
+    <attribute ref="xlink:from" use="optional"/> 
+    <attribute ref="xlink:to" use="optional"/> 
+  </attributeGroup>
+  <attributeGroup name="resourceLink">
+    <attribute name="type" type="string" fixed="resource" form="qualified"/> 
+    <attribute ref="xlink:role" use="optional"/> 
+    <attribute ref="xlink:title" use="optional"/> 
+    <attribute ref="xlink:label" use="optional"/> 
+  </attributeGroup>
+  <attributeGroup name="titleLink">
+    <attribute name="type" type="string" fixed="title" form="qualified"/> 
+  </attributeGroup>
+  <attributeGroup name="emptyLink">
+    <attribute name="type" type="string" fixed="none" form="qualified"/> 
+  </attributeGroup>
+</schema>

--- a/app/resources/xsd/xml.xsd
+++ b/app/resources/xsd/xml.xsd
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE xs:schema PUBLIC "-//W3C//DTD XMLSCHEMA 200102//EN" "XMLSchema.dtd">
+<xs:schema targetNamespace="http://www.w3.org/XML/1998/namespace" xmlns:xs="http://www.w3.org/2001/XMLSchema" xml:lang="en">
+
+ <xs:annotation>
+  <xs:documentation>
+   See http://www.w3.org/XML/1998/namespace.html and
+   http://www.w3.org/TR/REC-xml for information about this namespace.
+
+    This schema document describes the XML namespace, in a form
+    suitable for import by other schema documents.  
+
+    Note that local names in this namespace are intended to be defined
+    only by the World Wide Web Consortium or its subgroups.  The
+    following names are currently defined in this namespace and should
+    not be used with conflicting semantics by any Working Group,
+    specification, or document instance:
+
+    base (as an attribute name): denotes an attribute whose value
+         provides a URI to be used as the base for interpreting any
+         relative URIs in the scope of the element on which it
+         appears; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML Base specification.
+
+    lang (as an attribute name): denotes an attribute whose value
+         is a language code for the natural language of the content of
+         any element; its value is inherited.  This name is reserved
+         by virtue of its definition in the XML specification.
+  
+    space (as an attribute name): denotes an attribute whose
+         value is a keyword indicating what whitespace processing
+         discipline is intended for the content of the element; its
+         value is inherited.  This name is reserved by virtue of its
+         definition in the XML specification.
+
+    Father (in any context at all): denotes Jon Bosak, the chair of 
+         the original XML Working Group.  This name is reserved by 
+         the following decision of the W3C XML Plenary and 
+         XML Coordination groups:
+
+             In appreciation for his vision, leadership and dedication
+             the W3C XML Plenary on this 10th day of February, 2000
+             reserves for Jon Bosak in perpetuity the XML name
+             xml:Father
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>This schema defines attributes and an attribute group
+        suitable for use by
+        schemas wishing to allow xml:base, xml:lang or xml:space attributes
+        on elements they define.
+
+        To enable this, such a schema must import this schema
+        for the XML namespace, e.g. as follows:
+        &lt;schema . . .&gt;
+         . . .
+         &lt;import namespace="http://www.w3.org/XML/1998/namespace"
+                    schemaLocation="http://www.w3.org/2001/03/xml.xsd"/&gt;
+
+        Subsequently, qualified reference to any of the attributes
+        or the group defined below will have the desired effect, e.g.
+
+        &lt;type . . .&gt;
+         . . .
+         &lt;attributeGroup ref="xml:specialAttrs"/&gt;
+ 
+         will define a type which will schema-validate an instance
+         element with any of those attributes</xs:documentation>
+ </xs:annotation>
+
+ <xs:annotation>
+  <xs:documentation>In keeping with the XML Schema WG's standard versioning
+   policy, this schema document will persist at
+   http://www.w3.org/2001/03/xml.xsd.
+   At the date of issue it can also be found at
+   http://www.w3.org/2001/xml.xsd.
+   The schema document at that URI may however change in the future,
+   in order to remain compatible with the latest version of XML Schema
+   itself.  In other words, if the XML Schema namespace changes, the version
+   of this document at
+   http://www.w3.org/2001/xml.xsd will change
+   accordingly; the version at
+   http://www.w3.org/2001/03/xml.xsd will not change.
+  </xs:documentation>
+ </xs:annotation>
+
+ <xs:attribute name="lang" type="xs:language">
+  <xs:annotation>
+   <xs:documentation>In due course, we should install the relevant ISO 2- and 3-letter
+         codes as the enumerated possible values . . .</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attribute name="space" default="preserve">
+  <xs:simpleType>
+   <xs:restriction base="xs:NCName">
+    <xs:enumeration value="default"/>
+    <xs:enumeration value="preserve"/>
+   </xs:restriction>
+  </xs:simpleType>
+ </xs:attribute>
+
+ <xs:attribute name="base" type="xs:anyURI">
+  <xs:annotation>
+   <xs:documentation>See http://www.w3.org/TR/xmlbase/ for
+                     information about this attribute.</xs:documentation>
+  </xs:annotation>
+ </xs:attribute>
+
+ <xs:attributeGroup name="specialAttrs">
+  <xs:attribute ref="xml:base"/>
+  <xs:attribute ref="xml:lang"/>
+  <xs:attribute ref="xml:space"/>
+ </xs:attributeGroup>
+
+</xs:schema>


### PR DESCRIPTION
It should be self contained, meaning that all the XSD files should be locally available.
All links to the XSD resources referencing web URLs have been changed to the local ones.