### PR TITLE
DEV-2346 Add the serialization format in the event

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1,5 +1,4 @@
 from pathlib import Path
-import json
 
 from viaa.configuration import ConfigParser
 from viaa.observability import logging
@@ -21,6 +20,7 @@ from app.services.pulsar import (
 )
 
 APP_NAME = "sipin-sip-validator"
+METADATA_GRAPH_FMT = "turtle"
 
 
 class EventListener:
@@ -204,7 +204,8 @@ class EventListener:
                     self.sip_validate_shacl_topic,
                     {
                         "message": "Graph is conform.",
-                        "metadata_graph": json.loads(graph.serialize(format="json-ld")),
+                        "metadata_graph_fmt": METADATA_GRAPH_FMT,
+                        "metadata_graph": graph.serialize(format=METADATA_GRAPH_FMT),
                     },
                     msg_data["destination"],
                     EventOutcome.SUCCESS,

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -73,10 +73,12 @@ class TestEventListener:
         pulsar_binding_mock.from_protocol.return_value = event
         # There should be no errors when validating the metadata
         determine_profile_mock().validate_metadata.return_value = []
-        # Return JSON serialized in byte format when parsing the graph
-        determine_profile_mock().parse_graph().serialize.return_value = (
-            b'{"graph": "info"}'
-        )
+        # Return Turtle serialized in byte format when parsing the graph
+        turtle = b"""@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+        @prefix dc: <http://purl.org/dc/elements/1.1/> .
+
+        dc:title "Test" ."""
+        determine_profile_mock().parse_graph().serialize.return_value = turtle
 
         # Act
         event_listener.handle_incoming_message("")
@@ -106,7 +108,11 @@ class TestEventListener:
             ),
             (
                 "sip.validate.shacl",
-                {"message": "Graph is conform.", "metadata_graph": {"graph": "info"}},
+                {
+                    "message": "Graph is conform.",
+                    "metadata_graph_fmt": "turtle",
+                    "metadata_graph": turtle,
+                },
                 "test",
                 EventOutcome.SUCCESS,
                 "555",


### PR DESCRIPTION
This makes the event self-contained and the deserialization determinable.

Also, change the default value to turtle as this is more human-readable.