### PR TITLE
Bump PySPARQL-Anything

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ ENV PATH $JAVA_HOME/bin:$PATH
 
 # Download pysparql_anything in correct folder.
 RUN mkdir /usr/local/lib/python3.10/site-packages/pysparql_anything/ && \
-    wget -O /usr/local/lib/python3.10/site-packages/pysparql_anything/sparql-anything-v0.8.1.jar https://github.com/SPARQL-Anything/sparql.anything/releases/download/v0.8.1/sparql-anything-0.8.1.jar 
+    wget -O /usr/local/lib/python3.10/site-packages/pysparql_anything/sparql-anything-v0.8.2.jar https://github.com/SPARQL-Anything/sparql.anything/releases/download/v0.8.2/sparql-anything-0.8.2.jar 
 
 # Make a new group and user so we don't run as root.
 RUN addgroup --system appgroup && adduser --system appuser --ingroup appgroup

--- a/app/models/profile.py
+++ b/app/models/profile.py
@@ -7,6 +7,7 @@ from rdflib import Graph, URIRef
 from pyshacl import validate as shacl_validate
 from pysparql_anything import SparqlAnything
 
+sa = SparqlAnything()
 
 NAMESPACES = {
     "mets": "http://www.loc.gov/METS/",
@@ -341,7 +342,6 @@ class BasicProfile10(Profile):
             f.write(profile_template.render(bag_path=self.bag_path))
 
         # Run SPARQL-anything transformation.
-        sa = SparqlAnything()
         try:
             sip_graph = sa.construct(q=str(query_sip_destination), f="TTL")
             profile_descriptive_ie = sa.construct(
@@ -880,7 +880,6 @@ class MaterialArtworkProfile11(Profile):
             premis_representation_sparqls.append(premis_representation_sparql)
 
         # Run SPARQL-anything transformation.
-        sa = SparqlAnything()
         try:
             sip_graph = sa.construct(q=str(query_sip_destination), f="TTL")
             # Descriptive on IE level.
@@ -954,7 +953,6 @@ class MaterialArtworkProfile11(Profile):
 class NewspaperProfile11(Profile):
     def profile_name() -> str:
         return "https://data.hetarchief.be/id/sip/1.1/newspaper"
-
 
     @staticmethod
     def query_sip() -> Path:
@@ -1121,7 +1119,6 @@ class NewspaperProfile11(Profile):
                 errors.append(XMLNotValidError(str(e.error_log)))
 
         return errors
-
 
     def _validate_descriptive(self) -> list[XMLNotValidError]:
         """Validate the MODS or dc+schema files.
@@ -1359,7 +1356,6 @@ class NewspaperProfile11(Profile):
             file_page_sparqls.append(premis_file_page_sparql)
 
         # Run SPARQL-anything transformation.
-        sa = SparqlAnything()
         try:
             sip_graph = sa.construct(q=str(query_sip_destination), f="TTL")
             # Descriptive on IE level.
@@ -1391,9 +1387,7 @@ class NewspaperProfile11(Profile):
             # File page information.
             for file_page_sparql in file_page_sparqls:
 
-                profile_file_page = sa.construct(
-                    q=str(file_page_sparql), f="TTL"
-                )
+                profile_file_page = sa.construct(q=str(file_page_sparql), f="TTL")
                 data_graph = data_graph + profile_file_page
 
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,7 @@ pulsar-client==2.10.2
 viaa-chassis==0.2.0rc1
 meemoo-cloudevents==0.1.0rc3
 lxml==4.9.2
-rdflib==6.2.0
 pyshacl==0.20.0
 jinja2==3.1.2
 bagit==1.8.1
-pysparql_anything==0.8.1.1
+pysparql_anything==0.8.1.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ lxml==4.9.2
 pyshacl==0.20.0
 jinja2==3.1.2
 bagit==1.8.1
-pysparql_anything==0.8.1.2
+pysparql_anything==0.8.2.1


### PR DESCRIPTION
Bump to latest patch release of SPARQL-Anything (v0.8.2). As a result use PySPARQL-Anything v0.8.2.1.