### PR TITLE
DEV-2529 Add a consumer name

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -29,7 +29,7 @@ class EventListener:
         self.log = logging.get_logger(__name__, config=config_parser)
         self.config = config_parser.app_cfg
         # Init Pulsar client
-        self.pulsar_client = PulsarClient()
+        self.pulsar_client = PulsarClient(APP_NAME)
 
         # Topics
         app_config = self.config["sip-parser"]

--- a/app/services/pulsar.py
+++ b/app/services/pulsar.py
@@ -29,7 +29,9 @@ class PulsarClient:
             f'pulsar://{self.pulsar_config["host"]}:{self.pulsar_config["port"]}'
         )
         self.consumer: Consumer = self.client.subscribe(
-            self.app_config["consumer_topic"], app_name,
+            topic=self.app_config["consumer_topic"],
+            subscription_name=app_name,
+            consumer_name=app_name,
         )
         self.log.info(f"Started consuming topic: {self.app_config['consumer_topic']}")
         self.producers = {}

--- a/app/services/pulsar.py
+++ b/app/services/pulsar.py
@@ -20,7 +20,7 @@ class PulsarClient:
         producer: A Pulsar producer to send messages to.
     """
 
-    def __init__(self):
+    def __init__(self, app_name):
         config_parser = ConfigParser()
         self.log = logging.get_logger(__name__, config=config_parser)
         self.pulsar_config: dict = config_parser.app_cfg["pulsar"]
@@ -29,7 +29,7 @@ class PulsarClient:
             f'pulsar://{self.pulsar_config["host"]}:{self.pulsar_config["port"]}'
         )
         self.consumer: Consumer = self.client.subscribe(
-            self.app_config["consumer_topic"], "sipin-sip-validator"
+            self.app_config["consumer_topic"], app_name,
         )
         self.log.info(f"Started consuming topic: {self.app_config['consumer_topic']}")
         self.producers = {}


### PR DESCRIPTION
Add a consumer name for identification in Pulsar Manager.

The service currently creates the topic `sip-validator` and creates a subscription called `sipin-sip-validator`. This PR results in both being set to `sip-validator`. It might be best to standardize on `sipin-sip-validator` instead, if we're sure there are no services downstream using the old topic name.