### PR TITLE
DEV-2545 Fix DC XSD for basic 1.1

### DIFF
--- a/app/resources/1.1/basic/xsd/dc_basic.xsd
+++ b/app/resources/1.1/basic/xsd/dc_basic.xsd
@@ -2,7 +2,7 @@
 <xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:dcterms="http://purl.org/dc/terms/"
   xmlns:dc="http://purl.org/dc/elements/1.1/"
   xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
-  targetNamespace="https://data.hetarchief.be/id/sip/1.0/basic"
+  targetNamespace="https://data.hetarchief.be/id/sip/1.1/basic"
   elementFormDefault="qualified" attributeFormDefault="unqualified">
 
   <xs:annotation>

--- a/tests/resources/1.1/basic/sips/conform/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/conform/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 14264.6

--- a/tests/resources/1.1/basic/sips/conform/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/conform/data/metadata/descriptive/dc_1.xml
@@ -3,7 +3,7 @@
     xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <dcterms:identifier>uuid-6b80a848-f2d2-44a4-bc55-56f272a8e5b4</dcterms:identifier>
     <dcterms:title xml:lang="nl">Titel</dcterms:title>

--- a/tests/resources/1.1/basic/sips/conform/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/conform/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="606" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="52e02444e8da664c660e2179a46847ed" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="606" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5d60dcd075dd6aca324c64b95259d1e0" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/conform/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform/manifest-md5.txt
@@ -1,5 +1,5 @@
-89cd52d03e216b8b8189eb5090717328  data/mets.xml
-52e02444e8da664c660e2179a46847ed  data/metadata/descriptive/dc_1.xml
+1dfb688cc2c12b28eaddb8285493ad22  data/mets.xml
+5d60dcd075dd6aca324c64b95259d1e0  data/metadata/descriptive/dc_1.xml
 c23db62c2abd690a500940fe42948b5b  data/metadata/preservation/premis.xml
 e03cc894b11a9d40ef7c3980474255c9  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/conform/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-ebe1fd14db8274e1defad78414e82996 bag-info.txt
-8402ea233b930d4fb12c463b82d35533 manifest-md5.txt
+b44a8a199d76caa9d412bf0bf090dac6 bag-info.txt
+31c8d523056a9851a4971f2dc68317e0 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/conform_batch_id/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/bag-info.txt
@@ -1,4 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 14264.6
-Meemoo-Batch-Identifier: batch-id

--- a/tests/resources/1.1/basic/sips/conform_batch_id/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/bag-info.txt
@@ -1,3 +1,4 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
 Bagging-Date: 2024-06-20
 Payload-Oxum: 14264.6
+Meemoo-Batch-Identifier: batch-id

--- a/tests/resources/1.1/basic/sips/conform_batch_id/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/data/metadata/descriptive/dc_1.xml
@@ -3,7 +3,7 @@
     xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <dcterms:identifier>uuid-6b80a848-f2d2-44a4-bc55-56f272a8e5b4</dcterms:identifier>
     <dcterms:title xml:lang="nl">Titel</dcterms:title>

--- a/tests/resources/1.1/basic/sips/conform_batch_id/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="606" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="52e02444e8da664c660e2179a46847ed" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="606" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5d60dcd075dd6aca324c64b95259d1e0" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/conform_batch_id/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/manifest-md5.txt
@@ -1,5 +1,5 @@
-89cd52d03e216b8b8189eb5090717328  data/mets.xml
-52e02444e8da664c660e2179a46847ed  data/metadata/descriptive/dc_1.xml
+1dfb688cc2c12b28eaddb8285493ad22  data/mets.xml
+5d60dcd075dd6aca324c64b95259d1e0  data/metadata/descriptive/dc_1.xml
 c23db62c2abd690a500940fe42948b5b  data/metadata/preservation/premis.xml
 e03cc894b11a9d40ef7c3980474255c9  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/conform_batch_id/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-b288a889c3c37d2bd68fd866b7fce903 bag-info.txt
-8402ea233b930d4fb12c463b82d35533 manifest-md5.txt
+b44a8a199d76caa9d412bf0bf090dac6 bag-info.txt
+31c8d523056a9851a4971f2dc68317e0 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/conform_batch_id/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_batch_id/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-b44a8a199d76caa9d412bf0bf090dac6 bag-info.txt
+185df4ec2974e9afb59e63a9e7df60bb bag-info.txt
 31c8d523056a9851a4971f2dc68317e0 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/conform_extended/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/conform_extended/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 16482.6

--- a/tests/resources/1.1/basic/sips/conform_extended/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/conform_extended/data/metadata/descriptive/dc_1.xml
@@ -3,7 +3,7 @@
     xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <dcterms:title xml:lang="en">the title of the episode</dcterms:title>
     <dcterms:title xml:lang="nl">de titel van de episode</dcterms:title>

--- a/tests/resources/1.1/basic/sips/conform_extended/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/conform_extended/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="2823" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5746b89f6e15252fb54fcc2d7a74f1de" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="2823" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="de3b336633e8e1eecc0fdb86a0cf129d" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/conform_extended/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_extended/manifest-md5.txt
@@ -1,5 +1,5 @@
-ff00599db3c8f7ff7622b41b805fc46f  data/mets.xml
-5746b89f6e15252fb54fcc2d7a74f1de  data/metadata/descriptive/dc_1.xml
+1b70769bf64d15b951b969f69f5ed204  data/mets.xml
+de3b336633e8e1eecc0fdb86a0cf129d  data/metadata/descriptive/dc_1.xml
 c23db62c2abd690a500940fe42948b5b  data/metadata/preservation/premis.xml
 e03cc894b11a9d40ef7c3980474255c9  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/conform_extended/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_extended/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-598993a1d92bb1b0c74d2fd05585d8a0 bag-info.txt
-c1f150fe0051829c0e4f59610452c955 manifest-md5.txt
+dd28f2a72ecd6ca2d8378fa0734da260 bag-info.txt
+f0230dacafb578f290c61cb8205e7767 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/conform_local_ids/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/conform_local_ids/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 18678.6

--- a/tests/resources/1.1/basic/sips/conform_local_ids/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/conform_local_ids/data/metadata/descriptive/dc_1.xml
@@ -3,7 +3,7 @@
     xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <dcterms:identifier>uuid-6b80a848-f2d2-44a4-bc55-56f272a8e5b4</dcterms:identifier>
     <dcterms:title xml:lang="nl">Titel</dcterms:title>

--- a/tests/resources/1.1/basic/sips/conform_local_ids/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/conform_local_ids/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="606" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="52e02444e8da664c660e2179a46847ed" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="606" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="5d60dcd075dd6aca324c64b95259d1e0" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/conform_local_ids/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_local_ids/manifest-md5.txt
@@ -1,5 +1,5 @@
-df92cf04a64c3d34dfe602e7fc0b303c  data/mets.xml
-52e02444e8da664c660e2179a46847ed  data/metadata/descriptive/dc_1.xml
+153c2d64444f5e069a7f65b9e443321d  data/mets.xml
+5d60dcd075dd6aca324c64b95259d1e0  data/metadata/descriptive/dc_1.xml
 71039e5984dff60e6b6acc1378863fad  data/metadata/preservation/premis.xml
 e03cc894b11a9d40ef7c3980474255c9  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/conform_local_ids/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/conform_local_ids/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-45de5870baa750b7e017c6977d9798f8 bag-info.txt
-292d9c478c1835261957b1636c2ff0b1 manifest-md5.txt
+068c41d24ed28fafefa318f09ea35ade bag-info.txt
+2448190ae8bba84f02e403ed5ae7cc46 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/empty_graph/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/empty_graph/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 14074.6

--- a/tests/resources/1.1/basic/sips/empty_graph/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/empty_graph/data/metadata/descriptive/dc_1.xml
@@ -3,7 +3,7 @@
     xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <!-- velden obv. dcterms -->
     <!-- linking id between dc and premis -->

--- a/tests/resources/1.1/basic/sips/empty_graph/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/empty_graph/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="5918" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="f71206007a0bad5fcd57280c1ce4181f" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="5918" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="e62a1d5700030c986f9ac708752d7b37" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/empty_graph/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/empty_graph/manifest-md5.txt
@@ -1,5 +1,5 @@
-6134513f35818546837205d5478840d6  data/mets.xml
-f71206007a0bad5fcd57280c1ce4181f  data/metadata/descriptive/dc_1.xml
+331b1883d98b1ea6dbac57c526caf98f  data/mets.xml
+e62a1d5700030c986f9ac708752d7b37  data/metadata/descriptive/dc_1.xml
 3a43511c4797336e0fbde261c36e5dda  data/metadata/preservation/premis.xml
 b58f99f1a6c54016930fea0ff02645a6  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/empty_graph/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/empty_graph/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-518b9bbc8decccf919821b890b019f85 bag-info.txt
-85ed60289b1390d386bd74215a5bf92d manifest-md5.txt
+7fad04128e923439c9de30d082848553 bag-info.txt
+4c0effe330044b99fe9eebb0b27a3768 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/invalid_xml/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/invalid_xml/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 12058.6

--- a/tests/resources/1.1/basic/sips/invalid_xml/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/invalid_xml/data/metadata/descriptive/dc_1.xml
@@ -2,7 +2,7 @@
 <metadata xmlns:dcterms="http://purl.org/dc/terms/" xmlns:edtf="http://id.loc.gov/datatypes/edtf/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <dcterms:unknown>Unknown</dcterms:unknown>
 

--- a/tests/resources/1.1/basic/sips/invalid_xml/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/invalid_xml/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="362" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="286502a822adc0156c7f6a9010ba1d59" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="362" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="b9eb67807e1f4142fb00e169b03cd7ba" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/invalid_xml/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/invalid_xml/manifest-md5.txt
@@ -1,5 +1,5 @@
-3b492cde6ae89e84c5d081cf173b712a  data/mets.xml
-286502a822adc0156c7f6a9010ba1d59  data/metadata/descriptive/dc_1.xml
+b667ca530b675f5f196483c7bf2c73bd  data/mets.xml
+b9eb67807e1f4142fb00e169b03cd7ba  data/metadata/descriptive/dc_1.xml
 ca6c22e9ec0f3efa265fafa096958be0  data/metadata/preservation/premis.xml
 d9f9ede4d1a9007497061735b87a420e  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/invalid_xml/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/invalid_xml/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-f27155db03f580aef35fd9917b55ce1a bag-info.txt
-d97b7991b9347de4e7fc385d41b6f6cf manifest-md5.txt
+93d4f257459489076f7add056445e8b9 bag-info.txt
+cc8281de47e15ed8e8d75b49aa5ff43c manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt

--- a/tests/resources/1.1/basic/sips/not_conform/bag-info.txt
+++ b/tests/resources/1.1/basic/sips/not_conform/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
-Bagging-Date: 2024-03-02
+Bagging-Date: 2024-06-20
 Payload-Oxum: 21366.6

--- a/tests/resources/1.1/basic/sips/not_conform/data/metadata/descriptive/dc_1.xml
+++ b/tests/resources/1.1/basic/sips/not_conform/data/metadata/descriptive/dc_1.xml
@@ -3,7 +3,7 @@
     xmlns:schema="http://schema.org/"
     xmlns:xs="http://www.w3.org/2001/XMLSchema/"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://data.hetarchief.be/id/sip/1.0/basic">
+    xmlns="https://data.hetarchief.be/id/sip/1.1/basic">
 
     <!-- velden obv. dcterms -->
     <!-- linking id between dc and premis -->

--- a/tests/resources/1.1/basic/sips/not_conform/data/mets.xml
+++ b/tests/resources/1.1/basic/sips/not_conform/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE -->
     <dmdSec ID="uuid-4d18fdda-a20c-4410-9fce-30c6bff14f50">
-        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="7714" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="69859860a63ab0aaf221a0a17a5b98e3" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="DC" xlink:type="simple" xlink:href="metadata/descriptive/dc_1.xml" MIMETYPE="text/xml" SIZE="7714" CREATED="2022-02-16T10:01:15.014+02:00" CHECKSUM="a7044f7aba0ec63338f02ea3c622f945" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.1/basic/sips/not_conform/manifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/not_conform/manifest-md5.txt
@@ -1,5 +1,5 @@
-428c849f90e72060cbcebb161968e023  data/mets.xml
-69859860a63ab0aaf221a0a17a5b98e3  data/metadata/descriptive/dc_1.xml
+3ddce9ea2b24d19551fbe66369bdb92d  data/mets.xml
+a7044f7aba0ec63338f02ea3c622f945  data/metadata/descriptive/dc_1.xml
 fda206a31ce2eb27c8713589a53bf0f7  data/metadata/preservation/premis.xml
 b439df2aa2bee594604570fef9d02b2d  data/representations/representation_1/mets.xml
 02e4eb2f74ac06dd9cdfab861553697e  data/representations/representation_1/data/D523F963.jpg

--- a/tests/resources/1.1/basic/sips/not_conform/tagmanifest-md5.txt
+++ b/tests/resources/1.1/basic/sips/not_conform/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-6d5e2f3157e67638d014fe3896868f93 bag-info.txt
-fd9a2e69d238f932919b0afdb78175a9 manifest-md5.txt
+7479ef9e3ae015808459ebf4bf4a61a6 bag-info.txt
+697d52db979e4a40db1f66d1b5ef38ca manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt


### PR DESCRIPTION
The target namespace should be `https://data.hetarchief.be/id/sip/1.1/basic`