### PR TITLE
DEV-2606 Remove otherType restriction

### DIFF
--- a/app/resources/1.2/bibliographic/shacl/bibliographic.shacl.ttl
+++ b/app/resources/1.2/bibliographic/shacl/bibliographic.shacl.ttl
@@ -471,15 +471,6 @@
     [
         a sh:PropertyShape ;
         sh:path bf:variantType ;
-        sh:in ( "alternative" "incipit" "incipit brief" "correspondenten");
-        sh:severity sh:Violation ;
-        sh:message """Attribute '@type' of mods:titleInfo/mods:title[@type=*] must be 'alternative'
-and attribute '@othertype' should be one of 'incipit, incipit brief, correspondenten'.
-Please check `mods:mods/mods:titleInfo[@type="alternative"]`"""@en ;
-    ],
-    [
-        a sh:PropertyShape ;
-        sh:path bf:variantType ;
         sh:maxCount 2 ;
         sh:severity sh:Violation ;
         sh:message """Attribute '@type' of mods:titleInfo/mods:title[@type=*] element occurs more than once.

--- a/tests/resources/1.2/bibliographic/graph/conform_extended/graph.ttl
+++ b/tests/resources/1.2/bibliographic/graph/conform_extended/graph.ttl
@@ -261,7 +261,7 @@ haObjId:5278b4493206319864f8308a48a9617c a cryptographicHashFunctions:md5 ;
 haObjId:01b19476c174b17916370088d5a1bc24 a bf:VariantTitle ;
     rdfs:label "Newspaper title: alt" ;
     bf:variantType "alternative" ,
-        "incipit" .
+        "alt" .
 
 haObjId:7f59921f9e3fe99828e5705986ebe8c8 a cryptographicHashFunctions:md5 ;
     rdf:value "7f59921f9e3fe99828e5705986ebe8c8" .

--- a/tests/resources/1.2/bibliographic/sips/conform_extended/bag-info.txt
+++ b/tests/resources/1.2/bibliographic/sips/conform_extended/bag-info.txt
@@ -1,3 +1,3 @@
 Bag-Software-Agent: bagit.py v1.8.1 <https://github.com/LibraryOfCongress/bagit-python>
 Bagging-Date: 2024-04-29
-Payload-Oxum: 144973.39
+Payload-Oxum: 145571.39

--- a/tests/resources/1.2/bibliographic/sips/conform_extended/data/metadata/descriptive/mods.xml
+++ b/tests/resources/1.2/bibliographic/sips/conform_extended/data/metadata/descriptive/mods.xml
@@ -3,7 +3,7 @@
   <mods:titleInfo>
     <mods:title>Newspaper title</mods:title>
   </mods:titleInfo>
-  <mods:titleInfo type="alternative" otherType="incipit">
+  <mods:titleInfo type="alternative" otherType="alt">
     <mods:title>Newspaper title: alt</mods:title>
   </mods:titleInfo>
   <mods:identifier>uuid-9f07a3eb-1edb-4119-a98e-83ec7fd8d61c</mods:identifier>

--- a/tests/resources/1.2/bibliographic/sips/conform_extended/data/mets.xml
+++ b/tests/resources/1.2/bibliographic/sips/conform_extended/data/mets.xml
@@ -21,7 +21,7 @@
 
     <!-- ref to descriptive metadata about IE: MODS format -->
     <dmdSec ID="uuid-a75bdaf4-f9a8-49aa-9e92-dbe5ad164115">
-        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="./metadata/descriptive/mods.xml" MIMETYPE="text/xml" SIZE="2806" CREATED="2023-11-16T00:00:00+02:00" CHECKSUM="79346c8fa8e4733199a738c7a518937d" CHECKSUMTYPE="MD5"/>
+        <mdRef LOCTYPE="URL" MDTYPE="MODS" xlink:type="simple" xlink:href="./metadata/descriptive/mods.xml" MIMETYPE="text/xml" SIZE="3404" CREATED="2023-11-16T00:00:00+02:00" CHECKSUM="139a588c19bbb292141dab3115840209" CHECKSUMTYPE="MD5"/>
     </dmdSec>
 
     <!-- ref to the PREMIS metadata about IE/subIE(s)/package -->

--- a/tests/resources/1.2/bibliographic/sips/conform_extended/manifest-md5.txt
+++ b/tests/resources/1.2/bibliographic/sips/conform_extended/manifest-md5.txt
@@ -1,5 +1,5 @@
-5a97cd5f0721e1325416666bf562f393  data/mets.xml
-79346c8fa8e4733199a738c7a518937d  data/metadata/descriptive/mods.xml
+85ca4bc1d628fac0e86cbb215f1ff805  data/mets.xml
+139a588c19bbb292141dab3115840209  data/metadata/descriptive/mods.xml
 08412c3c14471b2335a4b322611313ce  data/metadata/preservation/premis.xml
 18027a1bb8d57d171d765d8fd45949e7  data/representations/representation_1/mets.xml
 ab9f05e1d16e3583fdfd6031cfaad3b0  data/representations/representation_1/data/page1.tif

--- a/tests/resources/1.2/bibliographic/sips/conform_extended/tagmanifest-md5.txt
+++ b/tests/resources/1.2/bibliographic/sips/conform_extended/tagmanifest-md5.txt
@@ -1,3 +1,3 @@
-859cd585d90af2b72ff554cf35c9fe55 bag-info.txt
-5cbae64e416a0498ccb857050b546f9a manifest-md5.txt
+50285ae632e33825c0c7138435d45e3c bag-info.txt
+947a35960608381830af8c50fd932334 manifest-md5.txt
 9e5ad981e0d29adc278f6a294b8c2aca bagit.txt


### PR DESCRIPTION
The attribute `mods:mods/mods:titleInfo[@type="alternative"]/@otherType` is now optional and not a curated list anymore.

Change the otherType attribute in the test resource to make sure that a value other than the original list is allowed.