### PR TITLE
FIx max count of typeOfResource

### DIFF
--- a/app/resources/1.2/bibliographic/shacl/bibliographic.shacl.ttl
+++ b/app/resources/1.2/bibliographic/shacl/bibliographic.shacl.ttl
@@ -150,7 +150,7 @@
     [
         a sh:PropertyShape ;
         sh:path rdf:type ;
-        sh:maxCount 3 ;
+        sh:maxCount 4 ;
         sh:severity sh:Violation ;
         sh:message """mods:typeOfResource element occurs more than once.
             Please check `mods:mods/mods:typeOfResource`"""@en ;


### PR DESCRIPTION
If the work is also a manuscript, this will count as an extra typeOfResource. Increase the count to four. A more correct way would be to ignore the manuscript type when counting the amount of types.